### PR TITLE
Fix large number clipping bug in Safari

### DIFF
--- a/src/styles/partials/section.css
+++ b/src/styles/partials/section.css
@@ -51,6 +51,10 @@
 }
 
 .section__header__title {
+  padding-left: var(
+    --s3
+  ); /* Safari clips the large number without this /shrug */
+
   letter-spacing: var(--tracked-mega);
 }
 


### PR DESCRIPTION
before:
![screen shot 2018-03-27 at 2 27 36 pm](https://user-images.githubusercontent.com/768965/37995965-0653e19c-31cb-11e8-8218-2f198927628b.png)

after:
![screen shot 2018-03-27 at 2 27 31 pm](https://user-images.githubusercontent.com/768965/37995968-088d8c9c-31cb-11e8-8beb-43dbf9fc735d.png)
