### PR TITLE
Add postcss plugins back to config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -27,7 +27,11 @@ module.exports = {
     {
       resolve: "gatsby-plugin-postcss-sass",
       options: {
-        postCssPlugins: [require("postcss-url")({ url: "inline" })]
+        postCssPlugins: [
+          require("postcss-import"),
+          require("postcss-url")({ url: "inline" }),
+          require("postcss-cssnext")
+        ]
       }
     },
     {


### PR DESCRIPTION
These postcss plugins are included by default with gatsby.